### PR TITLE
Add config setting to identify sensors by name rather than serial number

### DIFF
--- a/custom_components/uhoo/config_flow.py
+++ b/custom_components/uhoo/config_flow.py
@@ -8,7 +8,7 @@ from homeassistant.config_entries import CONN_CLASS_CLOUD_POLL, ConfigFlow
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import DOMAIN
+from .const import DOMAIN, CONF_NAMED_AS_SERIAL
 
 
 class UhooFlowHandler(ConfigFlow, domain=DOMAIN):
@@ -19,9 +19,11 @@ class UhooFlowHandler(ConfigFlow, domain=DOMAIN):
 
     def __init__(self):
         """Initialize the config flow."""
-        self.data_schema = vol.Schema(
-            {vol.Required(CONF_USERNAME): str, vol.Required(CONF_PASSWORD): str}
-        )
+        self.data_schema = vol.Schema({
+            vol.Required(CONF_USERNAME): str, 
+            vol.Required(CONF_PASSWORD): str,
+            vol.Optional(CONF_NAMED_AS_SERIAL, False): bool,
+        })
 
     async def _show_form(self, errors=None):
         """Show the form to the user."""

--- a/custom_components/uhoo/const.py
+++ b/custom_components/uhoo/const.py
@@ -29,6 +29,7 @@ ATTR_UNIT = "unit"
 ATTR_UNIQUE_ID = "unique_id"
 
 DATA_COORDINATOR = "coordinator"
+CONF_NAMED_AS_SERIAL = "Named as serial"
 
 DOMAIN = "uhoo"
 

--- a/custom_components/uhoo/sensor.py
+++ b/custom_components/uhoo/sensor.py
@@ -32,7 +32,7 @@ class UhooSensor(UhooEntity, Entity):
     @property
     def name(self):
         """Return the name of the particular component."""
-        return f"uHoo {self.serial_number} {SENSOR_TYPES[self.sensor_type][ATTR_LABEL]}"
+        return f"{self._uid} {SENSOR_TYPES[self.sensor_type][ATTR_LABEL]}"
 
     @property
     def state(self):
@@ -65,4 +65,4 @@ class UhooSensor(UhooEntity, Entity):
     @property
     def unique_id(self):
         """Return a unique id."""
-        return f"{self.serial_number}-{SENSOR_TYPES[self.sensor_type][ATTR_UNIQUE_ID]}"
+        return f"{self._unique_id}-{SENSOR_TYPES[self.sensor_type][ATTR_UNIQUE_ID]}"


### PR DESCRIPTION
I've got two uHoo's on my account and theyrre currently very hard to tell apart by the serial number, eg:
![image](https://user-images.githubusercontent.com/3318786/97819807-f99cb600-1cfe-11eb-99c8-5fa9ad1f8705.png)

This PR adds another config option to (by default) identify entities by name rather than serial, eg:
![image](https://user-images.githubusercontent.com/3318786/97819843-38cb0700-1cff-11eb-85c9-1e7c47515b92.png)


Existing users of the plugin should be unaffected by an upgrade, they'll still be named by the serial number. 
If serial is preferred, the config can be set true when the integration is added.